### PR TITLE
Fix 404 for drawer

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -112,7 +112,7 @@ const config = {
               },
               {
                 label: 'Drawer',
-                to: '/docs/components/Drawer',
+                to: '/docs/components/drawer',
               },
               {
                 label: 'Popover',


### PR DESCRIPTION
Remove capitalization for Drawer in footer URL