### PR TITLE
Removed extra circle from Delete Icon SVG

### DIFF
--- a/packages/react-icons/src/icons/delete.tsx
+++ b/packages/react-icons/src/icons/delete.tsx
@@ -50,7 +50,6 @@ export const DeleteIcon = React.forwardRef<SVGSVGElement, IconProps>(
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        <circle cx="16" cy="21.3333" r="1.33333" fill={color} />
       </svg>
     );
   }


### PR DESCRIPTION
Delete Icon SVG has extra circle element in-between lines. 

<img width="245" alt="Screenshot 2024-02-23 at 6 42 13 PM" src="https://github.com/surveysparrow/twigs/assets/46232883/4fc0ab60-6165-4b32-81c2-e711bfce5459">
