### PR TITLE
Fix issue Avatar group invalid size breaks layout

### DIFF
--- a/packages/react-components/src/avatar/avatar-group.tsx
+++ b/packages/react-components/src/avatar/avatar-group.tsx
@@ -74,6 +74,8 @@ const AvatarNestedItem = styled('div', {
   borderStyle: 'solid',
   borderRadius: '100%',
   zIndex: 0,
+  borderWidth: '2px',
+  marginLeft: '-$sizes$5',
   variants: {
     size: {
       '5xl': {

--- a/packages/react-components/src/avatar/avatar-group.tsx
+++ b/packages/react-components/src/avatar/avatar-group.tsx
@@ -74,7 +74,7 @@ const AvatarNestedItem = styled('div', {
   borderStyle: 'solid',
   borderRadius: '100%',
   zIndex: 0,
-  borderWidth: '2px',
+  borderWidth: '$sm',
   marginLeft: '-$sizes$5',
   variants: {
     size: {


### PR DESCRIPTION
Adding default borderWidth and marginLeft solves the issue.
<img width="707" alt="Screenshot 2024-03-18 at 2 47 19 PM" src="https://github.com/surveysparrow/twigs/assets/76246084/ee7f5990-0a32-45c1-b55a-91e02cfc5131">
