### PR TITLE
Fix issues with link tool when selection is empty

### DIFF
--- a/packages/react-components/rollup.config.base.js
+++ b/packages/react-components/rollup.config.base.js
@@ -47,14 +47,27 @@ module.exports = {
               return pathCache[p];
             }
 
-            if (fs.lstatSync(p).isDirectory()) {
-              if (fs.existsSync(path.resolve(p, 'index.ts'))) {
-                pathCache[p] = path.resolve(p, 'index.ts');
-                return path.resolve(p, 'index.ts');
+            if (fs.existsSync(p) && fs.lstatSync(p).isDirectory()) {
+              const tsResolvedPath = path.resolve(p, 'index.ts');
+              if (fs.existsSync(tsResolvedPath)) {
+                pathCache[p] = tsResolvedPath;
+                return tsResolvedPath;
               }
-              if (fs.existsSync(path.resolve(p, 'index.tsx'))) {
-                pathCache[p] = path.resolve(p, 'index.tsx');
-                return path.resolve(p, 'index.tsx');
+              const tsxResolvedPath = path.resolve(p, 'index.tsx');
+              if (fs.existsSync(tsxResolvedPath)) {
+                pathCache[p] = tsxResolvedPath;
+                return tsxResolvedPath;
+              }
+            } else {
+              const tsResolvedPath = path.resolve(`${p}.ts`);
+              if (fs.existsSync(tsResolvedPath)) {
+                pathCache[p] = tsResolvedPath;
+                return tsResolvedPath;
+              }
+              const tsxResolvedPath = path.resolve(`${p}.tsx`);
+              if (fs.existsSync(tsxResolvedPath)) {
+                pathCache[p] = tsxResolvedPath;
+                return tsxResolvedPath;
               }
             }
 

--- a/packages/react-components/src/editor/components/dialog-link-editor/index.tsx
+++ b/packages/react-components/src/editor/components/dialog-link-editor/index.tsx
@@ -5,6 +5,7 @@ import {
 } from '@lexical/link';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { $findMatchingParent, mergeRegister } from '@lexical/utils';
+import { ADD_BLANK_LINK } from '@src/editor/utils/commands';
 import {
   $getSelection,
   $isRangeSelection,
@@ -107,10 +108,10 @@ function useDialogLinkEditorToolbar(
       const node = getSelectedNode(selection);
       const parent = node.getParent();
       if ($isLinkNode(parent)) {
-        setLinkText(parent.getTextContent());
+        setLinkText(parent.getTextContent().trim());
         setLinkUrl(parent.getURL());
       } else if ($isLinkNode(node)) {
-        setLinkText(node.getTextContent());
+        setLinkText(node.getTextContent().trim());
         setLinkUrl(node.getURL());
       } else {
         setLinkText('');
@@ -169,6 +170,13 @@ function useDialogLinkEditorToolbar(
           updateLinkEditor();
         });
       }),
+      editor.registerCommand(ADD_BLANK_LINK, () => {
+        setTimeout(() => {
+          setIsLinkEditMode(true);
+        }, 40);
+        isNewLink.current = true;
+        return false;
+      }, COMMAND_PRIORITY_HIGH),
       editor.registerCommand(
         TOGGLE_LINK_COMMAND,
         (payload: string | { url: string } | null) => {

--- a/packages/react-components/src/editor/components/toolbar/tools/link.tsx
+++ b/packages/react-components/src/editor/components/toolbar/tools/link.tsx
@@ -1,8 +1,15 @@
-import { TOGGLE_LINK_COMMAND } from '@lexical/link';
+import { $createLinkNode, TOGGLE_LINK_COMMAND } from '@lexical/link';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { LinkIcon } from '@sparrowengg/twigs-react-icons';
 import { IconButton } from '@src/button';
+import { ADD_BLANK_LINK } from '@src/editor/utils/commands';
 import clsx from 'clsx';
+import {
+  $createTextNode,
+  $getSelection,
+  $insertNodes,
+  $isRangeSelection
+} from 'lexical';
 import { useToolbarStore } from '../../toolbar-context/store';
 import { ToolbarButtonProps } from './commons';
 
@@ -11,11 +18,32 @@ export const LinkTool = ({ renderButton, buttonProps }: ToolbarButtonProps) => {
   const [active] = useToolbarStore((state) => state.data.isLink);
 
   const handleClick = () => {
-    if (!active) {
-      editor.dispatchCommand(TOGGLE_LINK_COMMAND, 'https://');
-    } else {
-      editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
-    }
+    editor.update(() => {
+      const selection = $getSelection();
+      /**
+       * Handle link insertion when there is no selection (cursor blinking at a single point)
+       */
+      if (selection?.isCollapsed() && $isRangeSelection(selection)) {
+        const newLinkNode = $createLinkNode('https://');
+
+        // Completely empty string is not selectable, so we need to add a space.
+        // This space will be trimmed in the editor modal
+        newLinkNode.append($createTextNode(' '));
+
+        $insertNodes([newLinkNode]);
+        newLinkNode.select();
+
+        editor.dispatchCommand(ADD_BLANK_LINK, undefined);
+
+        return;
+      }
+
+      if (!active) {
+        editor.dispatchCommand(TOGGLE_LINK_COMMAND, 'https://');
+      } else {
+        editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
+      }
+    });
   };
 
   if (renderButton) {

--- a/packages/react-components/src/editor/utils/commands.ts
+++ b/packages/react-components/src/editor/utils/commands.ts
@@ -1,0 +1,3 @@
+import { LexicalCommand, createCommand } from 'lexical';
+
+export const ADD_BLANK_LINK: LexicalCommand<undefined> = createCommand('ADD_BLANK_LINK');


### PR DESCRIPTION
Handle link insertion and link editor dialog opening when link tool is used from the toolbar while selection is empty

Fixes #57 