### PR TITLE
Editor UI updates and bug fixes

### DIFF
--- a/packages/react-components/src/editor/components/dialog-link-editor/link-editor-dialog.tsx
+++ b/packages/react-components/src/editor/components/dialog-link-editor/link-editor-dialog.tsx
@@ -1,14 +1,10 @@
 import { CloseIcon, DeleteIcon } from '@sparrowengg/twigs-react-icons';
 import { Box } from '@src/box';
 import { Button, IconButton } from '@src/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle
-} from '@src/dialog';
+import { Dialog, DialogContent, DialogTitle } from '@src/dialog';
 import { Flex } from '@src/flex';
 import { FormInput } from '@src/input';
+import { Text } from '@src/text';
 import React, { useState } from 'react';
 
 export const LinkEditorDialog = ({
@@ -18,9 +14,12 @@ export const LinkEditorDialog = ({
   linkUrl,
   linkText,
   urlLabel,
+  isUpdate,
   textLabel,
+  saveLabel = 'Save',
   cancelLabel = 'Cancel',
   updateLabel = 'Update',
+  errorLabels,
   closeModal,
   removeLink,
   setIsLinkEditMode,
@@ -31,17 +30,23 @@ export const LinkEditorDialog = ({
   linkUrl: string;
   linkText: string;
   urlLabel: string;
+  isUpdate?: boolean;
   textLabel: string;
+  saveLabel?: string;
   cancelLabel?: string;
   updateLabel?: string;
+  errorLabels?: {
+    text?: string;
+    url?: string;
+  };
   closeModal: () => void;
   removeLink: () => void;
   handleLinkSubmission: ({ text, url }: { text: string; url: string }) => void;
-  setIsLinkEditMode: (isLinkEditMode: boolean) => void;
+  setIsLinkEditMode: (isEditMode: boolean) => void;
   errors: {
     text: boolean;
     url: boolean;
-  }
+  };
 }) => {
   const [editedLinkText, setEditedLinkText] = useState(linkText);
   const [editedLinkUrl, setEditedLinkUrl] = useState(linkUrl);
@@ -85,7 +90,9 @@ export const LinkEditorDialog = ({
             alignItems: 'center'
           }}
         >
-          <span>{title}</span>
+          <Text weight="bold" size="lg">
+            {title}
+          </Text>
           <IconButton
             onClick={closeModal}
             css={{
@@ -93,10 +100,10 @@ export const LinkEditorDialog = ({
             }}
             icon={<CloseIcon />}
             color="bright"
-            size="md"
+            size="lg"
           />
         </DialogTitle>
-        <DialogDescription
+        <Box
           css={{
             padding: '$8 $12'
           }}
@@ -113,11 +120,15 @@ export const LinkEditorDialog = ({
             css={{
               boxSizing: 'border-box'
             }}
-            error={errors.text ? 'Please enter a valid text' : undefined}
+            error={
+              errors.text
+                ? errorLabels?.text ?? 'Please enter a valid text'
+                : undefined
+            }
           />
           <Box
             css={{
-              marginTop: '$12'
+              marginTop: '$10'
             }}
           >
             <FormInput
@@ -132,43 +143,49 @@ export const LinkEditorDialog = ({
               css={{
                 boxSizing: 'border-box'
               }}
-              error={errors.url ? 'Please enter a valid URL' : undefined}
+              error={
+                errors.url
+                  ? errorLabels?.url ?? 'Please enter a valid URL'
+                  : undefined
+              }
             />
           </Box>
+        </Box>
+        <Flex
+          justifyContent="space-between"
+          css={{
+            padding: '$8 $12'
+          }}
+        >
+          <IconButton
+            icon={<DeleteIcon />}
+            color="bright"
+            size="lg"
+            onClick={removeLink}
+          />
           <Flex
             css={{
-              marginTop: '$6',
-              justifyContent: 'space-between'
+              gap: '$6'
             }}
           >
-            <IconButton
-              icon={<DeleteIcon />}
-              color="bright"
+            <Button color="default" size="lg" onClick={closeModal}>
+              {cancelLabel}
+            </Button>
+            <Button
+              color="primary"
               size="lg"
-              onClick={removeLink}
-              css={{}}
-            />
-            <Flex
-              css={{
-                gap: '$6'
-              }}
+              disabled={
+                editedLinkText === linkText && editedLinkUrl === linkUrl
+              }
+              onClick={() => handleLinkSubmission({
+                text: editedLinkText,
+                url: editedLinkUrl
+              })}
             >
-              <Button color="default" size="lg" onClick={closeModal}>
-                {cancelLabel}
-              </Button>
-              <Button
-                color="primary"
-                size="lg"
-                onClick={() => handleLinkSubmission({
-                  text: editedLinkText,
-                  url: editedLinkUrl
-                })}
-              >
-                {updateLabel}
-              </Button>
-            </Flex>
+              {isUpdate ? updateLabel : saveLabel}
+            </Button>
           </Flex>
-        </DialogDescription>
+        </Flex>
       </DialogContent>
     </Dialog>
   );

--- a/packages/react-components/src/editor/components/dialog-link-editor/link-tooltip.tsx
+++ b/packages/react-components/src/editor/components/dialog-link-editor/link-tooltip.tsx
@@ -41,7 +41,11 @@ export const LinkTooltip = ({
     >
       <Box
         css={{
-          flexShrink: 0
+          flexShrink: 0,
+
+          svg: {
+            display: 'block'
+          }
         }}
       >
         <LinkIcon color="#fff" size={16} />

--- a/packages/react-components/src/editor/components/rich-editor/index.tsx
+++ b/packages/react-components/src/editor/components/rich-editor/index.tsx
@@ -67,7 +67,7 @@ export const RichEditor = ({
                   padding: '0 $2',
                   backgroundColor: '$neutral100',
                   border: '1px solid $neutral200',
-                  borderRadius: '$md',
+                  borderRadius: '$sm',
 
                   '&, & *': {
                     fontFamily: 'monospace'

--- a/packages/react-components/src/editor/components/toolbar/tools/commons.ts
+++ b/packages/react-components/src/editor/components/toolbar/tools/commons.ts
@@ -1,5 +1,8 @@
+import { $setBlocksType } from '@lexical/selection';
 import { IconButtonBaseProps } from '@src/button';
-import { LexicalEditor } from 'lexical';
+import {
+  $createParagraphNode, $getSelection, $isRangeSelection, LexicalEditor
+} from 'lexical';
 import { ReactNode } from 'react';
 
 export type RenderButtonProps = {
@@ -11,4 +14,13 @@ export type RenderButtonProps = {
 export type ToolbarButtonProps = {
   renderButton?: (props: RenderButtonProps) => ReactNode;
   buttonProps?: IconButtonBaseProps;
+};
+
+export const formatParagraph = (editor: LexicalEditor) => {
+  editor.update(() => {
+    const selection = $getSelection();
+    if ($isRangeSelection(selection)) {
+      $setBlocksType(selection, () => $createParagraphNode());
+    }
+  });
 };

--- a/packages/react-components/src/editor/components/toolbar/tools/link.tsx
+++ b/packages/react-components/src/editor/components/toolbar/tools/link.tsx
@@ -24,7 +24,7 @@ export const LinkTool = ({ renderButton, buttonProps }: ToolbarButtonProps) => {
        * Handle link insertion when there is no selection (cursor blinking at a single point)
        */
       if (selection?.isCollapsed() && $isRangeSelection(selection)) {
-        const newLinkNode = $createLinkNode('https://');
+        const newLinkNode = $createLinkNode('');
 
         // Completely empty string is not selectable, so we need to add a space.
         // This space will be trimmed in the editor modal
@@ -39,7 +39,7 @@ export const LinkTool = ({ renderButton, buttonProps }: ToolbarButtonProps) => {
       }
 
       if (!active) {
-        editor.dispatchCommand(TOGGLE_LINK_COMMAND, 'https://');
+        editor.dispatchCommand(TOGGLE_LINK_COMMAND, '');
       } else {
         editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
       }

--- a/packages/react-components/src/editor/components/toolbar/tools/ordered-list.tsx
+++ b/packages/react-components/src/editor/components/toolbar/tools/ordered-list.tsx
@@ -1,13 +1,12 @@
 import {
-  INSERT_ORDERED_LIST_COMMAND,
-  REMOVE_LIST_COMMAND
+  INSERT_ORDERED_LIST_COMMAND
 } from '@lexical/list';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { OrderedListIcon } from '@sparrowengg/twigs-react-icons';
 import { IconButton } from '@src/button';
 import clsx from 'clsx';
 import { useToolbarStore } from '../../toolbar-context/store';
-import { ToolbarButtonProps } from './commons';
+import { ToolbarButtonProps, formatParagraph } from './commons';
 
 export const OrderedListTool = ({
   renderButton,
@@ -20,7 +19,7 @@ export const OrderedListTool = ({
     if (!active) {
       editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined);
     } else {
-      editor.dispatchCommand(REMOVE_LIST_COMMAND, undefined);
+      formatParagraph(editor);
     }
   };
 

--- a/packages/react-components/src/editor/components/toolbar/tools/unordered-list.tsx
+++ b/packages/react-components/src/editor/components/toolbar/tools/unordered-list.tsx
@@ -1,13 +1,12 @@
 import {
-  INSERT_UNORDERED_LIST_COMMAND,
-  REMOVE_LIST_COMMAND
+  INSERT_UNORDERED_LIST_COMMAND
 } from '@lexical/list';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { UnorderedListIcon } from '@sparrowengg/twigs-react-icons';
 import { IconButton } from '@src/button';
 import clsx from 'clsx';
 import { useToolbarStore } from '../../toolbar-context/store';
-import { ToolbarButtonProps } from './commons';
+import { ToolbarButtonProps, formatParagraph } from './commons';
 
 export const UnorderedListTool = ({
   renderButton,
@@ -20,7 +19,7 @@ export const UnorderedListTool = ({
     if (!active) {
       editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
     } else {
-      editor.dispatchCommand(REMOVE_LIST_COMMAND, undefined);
+      formatParagraph(editor);
     }
   };
 

--- a/packages/react-components/src/editor/plugins/hashtag/index.tsx
+++ b/packages/react-components/src/editor/plugins/hashtag/index.tsx
@@ -54,21 +54,23 @@ function checkForHashTags(
   return null;
 }
 
-function getPossibleQueryMatch(text: string): MenuTextMatch | null {
-  return checkForHashTags(text, 1);
+function getPossibleQueryMatch(text: string, len: number = 1): MenuTextMatch | null {
+  return checkForHashTags(text, len);
 }
 
 export const HashTagPlugin = ({
   getResults,
+  triggerStringLength,
   ...props
 }: Partial<EditorLookupDropdownBaseProps> & {
   getResults: (text: string | null) => TypeaheadMenuData[] | Promise<TypeaheadMenuData[]>;
+  triggerStringLength?: number;
 }) => {
   return (
     <EditorLookupDropdownBase
       $createNode={({ data }) => $createHashTagNode(`#${data.value}`)}
       getResults={getResults}
-      triggerFunction={(text) => getPossibleQueryMatch(text)}
+      triggerFunction={(text) => getPossibleQueryMatch(text, triggerStringLength)}
       {...props}
     />
   );

--- a/packages/react-components/src/editor/plugins/mentions/index.tsx
+++ b/packages/react-components/src/editor/plugins/mentions/index.tsx
@@ -76,21 +76,23 @@ function checkForAtSignMentions(
   return null;
 }
 
-function getPossibleQueryMatch(text: string): MenuTextMatch | null {
-  return checkForAtSignMentions(text, 1);
+function getPossibleQueryMatch(text: string, len: number = 1): MenuTextMatch | null {
+  return checkForAtSignMentions(text, len);
 }
 
 export const MentionsPlugin = ({
   getResults,
+  triggerStringLength,
   ...props
 }: Partial<EditorLookupDropdownBaseProps> & {
   getResults: (text: string | null) => TypeaheadMenuData[] | Promise<TypeaheadMenuData[]>;
+  triggerStringLength?: number;
 }) => {
   return (
     <EditorLookupDropdownBase
       $createNode={({ data }) => $createMentionNode(`@${data.value}`)}
       getResults={getResults}
-      triggerFunction={(text) => getPossibleQueryMatch(text)}
+      triggerFunction={(text) => getPossibleQueryMatch(text, triggerStringLength)}
       {...props}
     />
   );


### PR DESCRIPTION
- Add prop to control min length for trigger string in mentions and hashtag plugin
- Added props to control labels and other properties inside link dialog editor, updated UI to match design
- Reduce border radius of inline code
- Update list toolbar buttons to toggle current listitem only instead of entire block