### PR TITLE
Fix range calendar size issue for md variant

### DIFF
--- a/packages/react-components/src/calendar/calendar-range.tsx
+++ b/packages/react-components/src/calendar/calendar-range.tsx
@@ -32,6 +32,7 @@ import {
 } from './calendar-header';
 import { CalendarMonthsView } from './calendar-months-view';
 import {
+  CALENDAR_SIZE_TO_DAY_BTN_SIZE,
   CALENDAR_SIZE_TO_WIDTH,
   CalendarContext,
   CalendarControlProps,
@@ -245,8 +246,9 @@ const CalendarSingleSection = ({
               offset: calendarOffset
             })}
             containerCSS={{
-              maxWidth: 'max-content',
-              padding: '0 $8 $8 $8'
+              maxWidth: `calc(7 * ${CALENDAR_SIZE_TO_DAY_BTN_SIZE[calendarContext.size]})`,
+              boxSizing: 'content-box',
+              padding: '0 $8 0 $8'
             }}
           />
         </Flex>

--- a/packages/react-components/src/calendar/calendar-utils.ts
+++ b/packages/react-components/src/calendar/calendar-utils.ts
@@ -45,3 +45,8 @@ export const CALENDAR_SIZE_TO_BORDER_RADIUS: Record<CalendarSize, CSS<typeof con
   lg: '$2xl',
   md: '$xl'
 };
+
+export const CALENDAR_SIZE_TO_DAY_BTN_SIZE: Record<CalendarSize, CSS<typeof config>['width']> = {
+  lg: '$10',
+  md: '$8'
+};


### PR DESCRIPTION
Remove gap between days in md variant

<img width="583" alt="image" src="https://github.com/surveysparrow/twigs/assets/157568762/3ada5377-1866-4219-98ad-0c754a3d4bc9">

<img width="586" alt="image" src="https://github.com/surveysparrow/twigs/assets/157568762/00aa617f-ffd0-4493-85fb-19aa8807b442">
