### PR TITLE
Fix low lineheight causing line overlap in docs page

### DIFF
--- a/packages/docs/src/components/theming/font-sizes.tsx
+++ b/packages/docs/src/components/theming/font-sizes.tsx
@@ -36,7 +36,8 @@ export default function AllFontSizes() {
                 css={{
                   fontSize: fontSizes[fontSize],
                   marginTop: '10px',
-                  fontWeight: '500'
+                  fontWeight: '500',
+                  lineHeight: '1.3',
                 }}
               >
                 {defaultText}


### PR DESCRIPTION
Fixes this line overlap issue 

<img width="885" alt="image" src="https://github.com/user-attachments/assets/aadfb739-8275-4ece-a58a-b9c63038ac59">
