### PR TITLE
removed duplicate toast viewport

### DIFF
--- a/packages/react-components/src/toast/toastr.tsx
+++ b/packages/react-components/src/toast/toastr.tsx
@@ -5,8 +5,7 @@ import {
   ToastDescription,
   ToastProvider,
   ToastProviderProps,
-  ToastTitle,
-  ToastViewport
+  ToastTitle
 } from './toast';
 import { useToast } from '../hooks/use-toast';
 
@@ -45,7 +44,6 @@ export const Toastr: FunctionComponent<ToastProviderProps & { maxToasts?: number
           </Toast>
         );
       })}
-      <ToastViewport />
     </ToastProvider>
   );
 };


### PR DESCRIPTION
Removed duplicate `ToastViewport` component which was injecting two viewport containers to the DOM. This was affecting the auto dismissal of toasts in some cases. 

<img width="794" alt="image" src="https://github.com/user-attachments/assets/ae925a73-f10e-4f8f-ba01-2e3deebc87bf">
