### PR TITLE
Dialogs manager close control on buttons

### DIFF
--- a/packages/docs/docs/components/dialogs-manager.mdx
+++ b/packages/docs/docs/components/dialogs-manager.mdx
@@ -82,6 +82,55 @@ Used to close a particular dialog
 
 Used to close all open dialogs
 
+### Default dialogs props
+
+#### Alert
+
+| Property             | Description                                    | Type                                               | Default               |
+| -------------------- | ---------------------------------------------- | -------------------------------------------------- | --------------------- |
+| title                | Title of the dialog                            | ReactNode                                          | null                  |
+| content              | Content shown inside the dialog                | ReactNode                                          | null                  |
+| labels               | Labels for the buttons                         | `{ action: string }`                               | `{ action: "Close" }` |
+| actionButtonProps    | Props for the action button                    | `ButtonProps`                                      | {}                    |
+| closeButton          | Close button shown on the top right corner     | ReactNode                                          | ReactNode             |
+| css                  | Custom styles to be applied on the content     | `CSS`                                              | {}                    |
+| closeOnPrimaryAction | Close the dialog when action button is clicked | `boolean`                                          | true                  |
+| onPrimaryAction      | Callback when action button is clicked         | `(e: React.MouseEvent<HTMLButtonElement>) => void` | undefined             |
+| onClose              | Callback when dialog is closed                 | `() => void`                                       | undefined             |
+
+#### Confirm
+
+| Property           | Description                                     | Type                                               | Default                                    |
+| ------------------ | ----------------------------------------------- | -------------------------------------------------- | ------------------------------------------ |
+| title              | Title of the dialog                             | ReactNode                                          | null                                       |
+| content            | Content shown inside the dialog                 | ReactNode                                          | null                                       |
+| labels             | Labels for the buttons                          | `{ confirm: string; cancel: string }`              | `{ confirm: "Confirm", cancel: "Cancel" }` |
+| confirmButtonProps | Props for the confirm button                    | `ButtonProps`                                      | {}                                         |
+| cancelButtonProps  | Props for the cancel button                     | `ButtonProps`                                      | {}                                         |
+| closeButton        | Close button shown on the top right corner      | ReactNode                                          | ReactNode                                  |
+| css                | Custom styles to be applied on the content      | `CSS`                                              | {}                                         |
+| closeOnConfirm     | Close the dialog when confirm button is clicked | `boolean`                                          | true                                       |
+| closeOnCancel      | Close the dialog when cancel button is clicked  | `boolean`                                          | true                                       |
+| onConfirm          | Callback when confirm button is clicked         | `(e: React.MouseEvent<HTMLButtonElement>) => void` | undefined                                  |
+| onCancel           | Callback when cancel button is clicked          | `(e: React.MouseEvent<HTMLButtonElement>) => void` | undefined                                  |
+| onClose            | Callback when dialog is closed                  | `() => void`                                       | undefined                                  |
+
+#### Modal
+
+| Property             | Description                                                                                                             | Type                                               | Default               |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | --------------------- |
+| title                | Title of the dialog                                                                                                     | ReactNode                                          | null                  |
+| content              | Content shown inside the dialog                                                                                         | ReactNode                                          | null                  |
+| footer               | Dialog footer                                                                                                           | ReactNode                                          | ReactNode             |
+| children             | If provided, completely override the content of the dialog, ignoring all the other props like title, content and footer | ReactNode                                          | ReactNode             |
+| labels               | Labels for the buttons                                                                                                  | `{ action: string }`                               | `{ action: "Close" }` |
+| actionButtonProps    | Props for the action button                                                                                             | `ButtonProps`                                      | {}                    |
+| closeButton          | Close button shown on the top right corner                                                                              | ReactNode                                          | ReactNode             |
+| css                  | Custom styles to be applied on the content                                                                              | `CSS`                                              | {}                    |
+| closeOnPrimaryAction | Close the dialog when action button is clicked                                                                          | `boolean`                                          | true                  |
+| onPrimaryAction      | Callback when action button is clicked                                                                                  | `(e: React.MouseEvent<HTMLButtonElement>) => void` | undefined             |
+| onClose              | Callback when dialog is closed                                                                                          | `() => void`                                       | undefined             |
+
 ### Typesafe options
 
 When creating custom dialogs, you can ensure type safety to `dialogs.open` and `dialogs.push` by overriding the `DialogOptionsOverride` interface as shown below

--- a/packages/react-components/src/dialog/dialogs-manager/default-alert.tsx
+++ b/packages/react-components/src/dialog/dialogs-manager/default-alert.tsx
@@ -25,6 +25,7 @@ export type DefaultAlertDialogProps = {
   closeButton?: ReactNode;
   css?: CSS<typeof config>;
   onPrimaryAction?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  closeOnPrimaryAction?: boolean;
   onClose?: () => void;
 };
 
@@ -36,6 +37,7 @@ export const DefaultAlertDialog = ({
   },
   actionButtonProps,
   closeButton = DefaultCloseButton,
+  closeOnPrimaryAction = true,
   css,
   onPrimaryAction,
   onClose
@@ -58,16 +60,16 @@ export const DefaultAlertDialog = ({
         >
           {title}
           {closeButton && (
-          <Box
-            css={{
-              position: 'absolute',
-              top: '50%',
-              right: '$12',
-              transform: 'translate(0,-50%)'
-            }}
-          >
-            {closeButton}
-          </Box>
+            <Box
+              css={{
+                position: 'absolute',
+                top: '50%',
+                right: '$12',
+                transform: 'translate(0,-50%)'
+              }}
+            >
+              {closeButton}
+            </Box>
           )}
         </AlertDialogTitle>
         <AlertDialogDescription>{content}</AlertDialogDescription>
@@ -77,7 +79,7 @@ export const DefaultAlertDialog = ({
             justifyContent: 'flex-end'
           }}
         >
-          <AlertDialogAction asChild>
+          <ActionWrapper closeOnPrimaryAction={closeOnPrimaryAction}>
             {isValidElement(labels.action) ? (
               labels.action
             ) : (
@@ -90,11 +92,25 @@ export const DefaultAlertDialog = ({
                 {labels.action}
               </Button>
             )}
-          </AlertDialogAction>
+          </ActionWrapper>
         </AlertDialogActions>
       </AlertDialogContent>
     </AlertDialog>
   );
+};
+
+const ActionWrapper = ({
+  children,
+  closeOnPrimaryAction
+}: {
+  children: ReactNode;
+  closeOnPrimaryAction: boolean;
+}) => {
+  if (closeOnPrimaryAction) {
+    return <AlertDialogAction asChild>{children}</AlertDialogAction>;
+  }
+
+  return <>{children}</>;
 };
 
 const DefaultCloseButton = (

--- a/packages/react-components/src/dialog/dialogs-manager/default-confirm.tsx
+++ b/packages/react-components/src/dialog/dialogs-manager/default-confirm.tsx
@@ -25,6 +25,8 @@ export type DefaultConfirmDialogProps = {
   confirmButtonProps?: ButtonProps;
   cancelButtonProps?: ButtonProps;
   closeButton?: ReactNode;
+  closeOnConfirm?: boolean;
+  closeOnCancel?: boolean;
   onConfirm?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onCancel?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onClose?: () => void;
@@ -40,6 +42,8 @@ export const DefaultConfirmDialog = ({
   },
   cancelButtonProps,
   confirmButtonProps,
+  closeOnCancel = true,
+  closeOnConfirm = true,
   closeButton = DefaultCloseButton,
   css,
   onConfirm,
@@ -83,7 +87,7 @@ export const DefaultConfirmDialog = ({
           }}
         >
           {labels.cancel && (
-            <AlertDialogCancel asChild>
+            <CancelButtonWrapper closeOnCancel={closeOnCancel}>
               {isValidElement(labels.cancel) ? (
                 labels.cancel
               ) : (
@@ -96,10 +100,10 @@ export const DefaultConfirmDialog = ({
                   {labels.cancel}
                 </Button>
               )}
-            </AlertDialogCancel>
+            </CancelButtonWrapper>
           )}
           {labels.confirm && (
-            <AlertDialogAction asChild>
+            <ConfirmButtonWrapper closeOnConfirm={closeOnConfirm}>
               {isValidElement(labels.confirm) ? (
                 labels.confirm
               ) : (
@@ -112,12 +116,40 @@ export const DefaultConfirmDialog = ({
                   {labels.confirm}
                 </Button>
               )}
-            </AlertDialogAction>
+            </ConfirmButtonWrapper>
           )}
         </AlertDialogActions>
       </AlertDialogContent>
     </AlertDialog>
   );
+};
+
+const CancelButtonWrapper = ({
+  children,
+  closeOnCancel
+}: {
+  children: ReactNode;
+  closeOnCancel: boolean;
+}) => {
+  if (closeOnCancel) {
+    return <AlertDialogCancel asChild>{children}</AlertDialogCancel>;
+  }
+
+  return <>{children}</>;
+};
+
+const ConfirmButtonWrapper = ({
+  children,
+  closeOnConfirm
+}: {
+  children: ReactNode;
+  closeOnConfirm: boolean;
+}) => {
+  if (closeOnConfirm) {
+    return <AlertDialogAction asChild>{children}</AlertDialogAction>;
+  }
+
+  return <>{children}</>;
 };
 
 const DefaultCloseButton = (

--- a/packages/react-components/src/dialog/dialogs-manager/default-modal.tsx
+++ b/packages/react-components/src/dialog/dialogs-manager/default-modal.tsx
@@ -26,6 +26,7 @@ export type DefaultInfoDialogProps = {
   };
   closeButton?: ReactNode;
   css?: CSS<typeof config>;
+  closeOnPrimaryAction?: boolean;
   onPrimaryAction?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onClose?: () => void;
 };
@@ -39,6 +40,7 @@ export const DefaultModal = ({
   labels = {
     action: 'Close'
   },
+  closeOnPrimaryAction = true,
   closeButton = DefaultCloseButton,
   css,
   onClose,
@@ -89,17 +91,31 @@ export const DefaultModal = ({
                   justifyContent: 'flex-end'
                 }}
               >
-                <DialogClose asChild>
+                <ActionWrapper closeOnPrimaryAction={closeOnPrimaryAction}>
                   <Button size="lg" color="default" onClick={onPrimaryAction}>
                     {labels?.action}
                   </Button>
-                </DialogClose>
+                </ActionWrapper>
               </Flex>
             )}
           </>
         )}
       </DialogContent>
     </Dialog>
+  );
+};
+
+const ActionWrapper = ({
+  children,
+  closeOnPrimaryAction
+}: {
+  children: ReactNode;
+  closeOnPrimaryAction?: boolean;
+}) => {
+  return closeOnPrimaryAction ? (
+    <DialogClose asChild>{children}</DialogClose>
+  ) : (
+    <>{children}</>
   );
 };
 


### PR DESCRIPTION
- Add props to control whether actions button in dialogs close the dialog
- Update docs to include props of default dialogs provided in dialogs manager