### PR TITLE
Releases 05-06 sep 2024

### DIFF
--- a/packages/docs/docs/components/datepicker.mdx
+++ b/packages/docs/docs/components/datepicker.mdx
@@ -57,3 +57,4 @@ function App() {
 | renderFooter         | Custom footer component                                                 | `(state: CalendarState) => ReactNode` |          |
 | containerCSS         | Custom CSS for the container element                                    | `CSS`                                 |          |
 | calendarContainerCSS | Custom CSS for the calendar container element                           | `CSS`                                 |          |
+| popoverContentProps  | Additional props to be passed to the popover content component          | `PopoverContentProps`                 |          |

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -140,6 +140,7 @@
     "@radix-ui/react-radio-group": "^1.2.0",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slider": "^1.2.0",
+    "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparrowengg/twigs-react",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "In house component library for SurveySparrow",
   "module": "dist/es/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/react-components/src/datepicker/datepicker.tsx
+++ b/packages/react-components/src/datepicker/datepicker.tsx
@@ -1,9 +1,12 @@
 import { getLocalTimeZone, today } from '@internationalized/date';
 import { CalendarIcon } from '@sparrowengg/twigs-react-icons';
 import { CSS } from '@stitches/react';
-import { ReactNode, useEffect, useRef } from 'react';
+import {
+  ComponentProps, ReactNode, useEffect, useRef
+} from 'react';
 import { AriaDatePickerProps, DateValue, useDatePicker } from 'react-aria';
 import { CalendarState, useDatePickerState } from 'react-stately';
+import { prefixClassName } from '@src/utils';
 import { Box } from '../box';
 import { IconButton } from '../button';
 import { Calendar } from '../calendar';
@@ -37,6 +40,7 @@ export type DatePickerProps = AriaDatePickerProps<DateValue> & {
   contentStyle?: CSS;
   portalTarget?: Element | null | undefined;
   calendarContainerCSS?: CalendarControlProps['containerCSS'];
+  popoverContentProps?: ComponentProps<typeof PopoverContent>;
 } & CalendarControlProps;
 
 export const DatePicker = ({
@@ -50,6 +54,7 @@ export const DatePicker = ({
   contentStyle,
   portalTarget,
   containerCSS,
+  popoverContentProps,
   calendarContainerCSS,
   onDaySelect,
   onMonthSelect,
@@ -97,30 +102,33 @@ export const DatePicker = ({
       )}
 
       <Popover open={state.isOpen} onOpenChange={state.toggle}>
-        <PopoverTrigger asChild>
+        <Box
+          {...groupProps}
+          className={prefixClassName('datepicker__field-container')}
+          ref={ref}
+          css={{
+            display: 'inline-flex',
+            width: 'auto',
+            background: '$black50',
+            border: 'none',
+            padding: '$4 $6',
+            borderRadius: '$lg',
+            justifyContent: 'space-between'
+          }}
+        >
           <Box
-            {...groupProps}
-            ref={ref}
             css={{
-              display: 'inline-flex',
-              width: 'auto',
-              background: '$black50',
-              border: 'none',
-              padding: '$4 $6',
-              borderRadius: '$lg'
+              position: 'relative',
+              transition: 'all 200ms',
+              display: 'flex',
+              alignItems: 'center'
             }}
+            className={prefixClassName('datepicker__field')}
+            ref={ref}
           >
-            <Box
-              css={{
-                position: 'relative',
-                transition: 'all 200ms',
-                display: 'flex',
-                alignItems: 'center'
-              }}
-              ref={ref}
-            >
-              <DateField {...fieldProps} />
-            </Box>
+            <DateField {...fieldProps} />
+          </Box>
+          <PopoverTrigger asChild>
             <IconButton
               {...buttonProps}
               onClick={state.open}
@@ -133,11 +141,15 @@ export const DatePicker = ({
               type="button"
               icon={<CalendarIcon />}
             />
-          </Box>
-        </PopoverTrigger>
+          </PopoverTrigger>
+        </Box>
         <PopoverWrapper enablePortal={enablePortal} portalTarget={portalTarget}>
           <PopoverContent
             {...dialogProps}
+            align="end"
+            sideOffset={10}
+            alignOffset={-12}
+            {...popoverContentProps}
             css={{
               width: 'auto',
               padding: '0',

--- a/packages/react-components/src/link/link.tsx
+++ b/packages/react-components/src/link/link.tsx
@@ -1,30 +1,58 @@
-import React, { FunctionComponent } from 'react';
-import { Box, BoxProps } from '../box';
+import { Slot } from '@radix-ui/react-slot';
+import { CSS } from '@stitches/react';
+import React, {
+  ComponentProps, ForwardedRef,
+  ReactNode, Ref
+} from 'react';
+import { config, styled } from '../stitches.config';
 
-type LinkProps = BoxProps & React.AnchorHTMLAttributes<HTMLAnchorElement>;
-
-export const Link: FunctionComponent<LinkProps> = React.forwardRef(
-  ({ children, css, ...rest }: LinkProps, ref) => {
-    return (
-      <Box
-        ref={ref}
-        as="a"
-        css={{
-          color: '$link',
-          fontWeight: 'inherit',
-          textDecoration: 'none',
-          display: 'inline-block',
-          '&:focus, &:active': {
-            outline: 'none'
-          },
-          ...css
-        }}
-        tabIndex={0}
-        data-testid="link"
-        {...rest}
-      >
-        {children}
-      </Box>
-    );
+const defaultStyle: CSS<typeof config> = {
+  color: '$neutral800',
+  fontWeight: 'inherit',
+  textDecoration: 'none',
+  display: 'inline-block',
+  '&:focus, &:active': {
+    outline: 'none'
   }
-);
+};
+
+const StyledSlot = styled(Slot, {
+  ...defaultStyle
+});
+
+const StyledAnchor = styled('a', defaultStyle);
+
+type BaseLinkProps = ComponentProps<typeof StyledAnchor>;
+
+type SlotLinkProps = {
+  css?: BaseLinkProps['css'];
+  asChild?: boolean;
+  children?: ReactNode;
+}
+
+export type LinkProps = BaseLinkProps & {
+  asChild?: boolean;
+};
+
+const LinkComponent = <
+  TProps extends LinkProps,
+  TRef extends HTMLElement
+>(
+    props: TProps & SlotLinkProps,
+    ref: ForwardedRef<TRef>
+  ) => {
+  const { asChild, children, ...rest } = props;
+  const RootComp = asChild ? StyledSlot : StyledAnchor;
+  return (
+    <RootComp ref={ref} data-testid="link" {...rest}>
+      {children}
+    </RootComp>
+  );
+};
+
+export const Link = React.forwardRef(LinkComponent) as <
+  TProps extends LinkProps,
+  TRef extends HTMLElement
+>(
+  p: TProps & SlotLinkProps & { ref?: Ref<TRef> }
+) => React.JSX.Element;

--- a/packages/react-components/src/link/stories/link.stories.tsx
+++ b/packages/react-components/src/link/stories/link.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Link } from '../link';
 
@@ -9,6 +8,9 @@ export default {
     size: {
       control: 'select',
       options: ['md', 'lg', 'xl']
+    },
+    asChild: {
+      control: 'boolean'
     }
   }
 } as ComponentMeta<typeof Link>;

--- a/packages/react-components/src/link/tests/index.test.tsx
+++ b/packages/react-components/src/link/tests/index.test.tsx
@@ -10,19 +10,26 @@ describe('Link', () => {
   });
 
   it('renders Link correctly', () => {
-    const { getByTestId } = render(
-      <Link href="/">Simple Link</Link>
-    );
+    const { getByTestId } = render(<Link href="/">Simple Link</Link>);
     const link = getByTestId('link');
     expect(link).toHaveTextContent('Simple Link');
+  });
+
+  it('renders Link with asChild prop', () => {
+    const { getByTestId } = render(
+      <Link asChild href="!#">
+        <div title="Not Link">Simple Link</div>
+      </Link>
+    );
+    const link = getByTestId('link');
+    expect(link.tagName).toBe('DIV');
+    expect(link).toHaveAttribute('title', 'Not Link');
   });
 });
 
 describe('given a link with href prop', () => {
   it('should have the correct href value', () => {
-    const { getByTestId } = render(
-      <Link href="test">Simple Link</Link>
-    );
+    const { getByTestId } = render(<Link href="test">Simple Link</Link>);
     const link = getByTestId('link');
     expect(link).toHaveAttribute('href', 'test');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1942,7 +1942,7 @@
     "@docusaurus/theme-search-algolia" "2.4.1"
     "@docusaurus/types" "2.4.1"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -4126,7 +4126,7 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.1"
 
-"@radix-ui/react-slot@1.1.0":
+"@radix-ui/react-slot@1.1.0", "@radix-ui/react-slot@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.0.tgz#7c5e48c36ef5496d97b08f1357bb26ed7c714b84"
   integrity sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==
@@ -17009,6 +17009,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
+
 react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz"
@@ -18532,7 +18540,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18632,7 +18649,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -20124,7 +20148,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20137,6 +20161,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
- Support `asChild` prop in `Link` component
- Add `popoverContentProps` support to datepicker and update its trigger to target calendar icon only