### PR TITLE
Fix chevron direction when accordions are nested

### DIFF
--- a/packages/react-components/src/accordion/accordion.tsx
+++ b/packages/react-components/src/accordion/accordion.tsx
@@ -21,7 +21,7 @@ const StyledTrigger = styled(AccordionPrimitive.Trigger, {
   paddingInlineEnd: '$8',
   paddingTop: '$2',
   paddingBottom: '$2',
-  [`[data-state=open] & ${StyledChevron}`]: {
+  [`[data-state=open] > & ${StyledChevron}`]: {
     transform: 'rotate(180deg)'
   },
   '&:hover': {


### PR DESCRIPTION
Currently when an accordion is nested inside another, the chevron in the child accordion will always be pointing in the parent's direction