### PR TITLE
Add 'filled' Variant Prop to Alert

### DIFF
--- a/packages/react-components/src/alert/alert.tsx
+++ b/packages/react-components/src/alert/alert.tsx
@@ -98,8 +98,52 @@ const StyledAlert = styled(Box, {
           color: '$warning600'
         }
       }
-    }
+    },
+    variant: {
+      filled: {
+        backgroundColor: 'currentColor',
+        color: 'currentColor',
+        border: 'none',
+        [`${StyledAlertIcon} svg`]: {
+          color: 'currentColor !important'
+        }
+      }
+    },
   },
+  compoundVariants: [
+    {
+      status: STATUSES.success.name,
+      variant: 'filled',
+      css: {
+        backgroundColor: '$positive500',
+        color: '$white900'
+      }
+    },
+    {
+      status: STATUSES.info.name,
+      variant: 'filled',
+      css: {
+        backgroundColor: '$accent500',
+        color: '$white900'
+      }
+    },
+    {
+      status: STATUSES.warning.name,
+      variant: 'filled',
+      css: {
+        backgroundColor: '$warning500',
+        color: '$white900'
+      }
+    },
+    {
+      status: STATUSES.error.name,
+      variant: 'filled',
+      css: {
+        backgroundColor: '$negative600',
+        color: '$white900'
+      }
+    }
+  ],
   defaultVariants: {
     size: 'sm',
     status: STATUSES.info.name
@@ -112,6 +156,7 @@ export type AlertProps = {
   onClose?: React.MouseEventHandler<HTMLButtonElement>
   status: 'info' | 'error' | 'success' | 'warning',
   icon?: React.ReactElement,
+  variant?: string
 } & ComponentProps<typeof StyledAlert>
 
 export const Alert: FunctionComponent<AlertProps> = React.forwardRef(
@@ -122,6 +167,7 @@ export const Alert: FunctionComponent<AlertProps> = React.forwardRef(
     status = 'info',
     children,
     icon,
+    variant,
     ...rest
   }: AlertProps, ref) => {
     const ValidAlertIcon = icon || STATUSES[status]?.icon;
@@ -135,6 +181,7 @@ export const Alert: FunctionComponent<AlertProps> = React.forwardRef(
         ref={ref}
         size={size}
         status={status}
+        variant={variant}
         {...rest}
       >
         <StyledAlertIcon

--- a/packages/react-components/src/alert/alert.tsx
+++ b/packages/react-components/src/alert/alert.tsx
@@ -207,7 +207,7 @@ export const Alert: FunctionComponent<AlertProps> = React.forwardRef(
               <StyledCloseButton
                 icon={<CloseIcon />}
                 aria-label="close"
-                color="default"
+                color={variant === 'filled' ? 'light' : 'default'}
                 {...(onClose && { onClick: onClose })}
               />
             )


### PR DESCRIPTION

This pull request adds the following background colors for the Alert component:

- **Success:** `$positive500`
- **Info:** `$accent500`
- **Warning:** `$warning500`
- **Error:** `$negative600`

The text color and icon will be set to `$white900`.

Please let me know if these color choices are acceptable , or let me know if you would like any adjustments to the color codes.