### PR TITLE
Apply classnames and other patches

### DIFF
--- a/packages/react-components/src/editor/components/toolbar/tools/format.tsx
+++ b/packages/react-components/src/editor/components/toolbar/tools/format.tsx
@@ -86,7 +86,7 @@ export const FormatTool = ({
           className="twigs-editor-tool-button"
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent>
+      <DropdownMenuContent className="twigs-editor-toolbar__format-options">
         <DropdownMenuItem onClick={formatParagraph}>
           {paragraph}
         </DropdownMenuItem>

--- a/packages/react-components/src/stitches.config.ts
+++ b/packages/react-components/src/stitches.config.ts
@@ -346,8 +346,10 @@ export const globalStyles = globalCss({
   '*': {
     margin: 0,
     padding: 0,
-    fontFamily: '$body',
     '-webkit-font-smoothing': 'antialiased'
+  },
+  'html, body, textarea, input, button, select, p, a': {
+    fontFamily: '$body'
   },
   '*, :before, :after': { boxSizing: 'border-box' }
 });


### PR DESCRIPTION
- Move font family to specific elements instead of using wildcard
- Add classname to toolbar format options