### PR TITLE
changed from bold to medium

### DIFF
--- a/packages/react-components/src/datepicker/date-time-segment.tsx
+++ b/packages/react-components/src/datepicker/date-time-segment.tsx
@@ -36,7 +36,7 @@ export const DateTimeSegment = ({ segment, state }: DateTimeSegmentProps) => {
     >
       <Text
         size="md"
-        weight="bold"
+        weight="medium"
         css={{
           color: '$neutral800'
         }}

--- a/packages/react-components/src/stitches.config.ts
+++ b/packages/react-components/src/stitches.config.ts
@@ -15,9 +15,9 @@ export const resetStyles = {
     verticalAlign: 'baseline'
   },
   'article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section':
-    {
-      display: 'block'
-    },
+  {
+    display: 'block'
+  },
   '*[hidden]': {
     display: 'none'
   },
@@ -354,7 +354,7 @@ export const globalStyles = globalCss({
   '*, :before, :after': { boxSizing: 'border-box' }
 });
 
-function hexToRgba(hex: string, opacity: number) {
+export function hexToRgba(hex: string, opacity: number) {
   const color = theme.colors[hex.replace('$', '')];
   if (!color) return hex;
   const r = parseInt(color.value.substring(1, 3), 16);


### PR DESCRIPTION
1. Font weight is medium for date picker text input
![image](https://github.com/user-attachments/assets/e9104d41-6ba7-4a62-abdd-2bcc65ca6322)

2. exported `hexToRgba`. Useful in creating opacity colors from theme token for box shadow and anything outside of `backgroundColorOpacity`, `colorOpacity`, `borderColorOpacity`