### PR TITLE
Fixes missing dates in December 2024 for range calendar

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparrowengg/twigs-react",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "description": "In house component library for SurveySparrow",
   "module": "dist/es/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/react-components/src/calendar/calendar-grid.tsx
+++ b/packages/react-components/src/calendar/calendar-grid.tsx
@@ -45,7 +45,7 @@ export const CalendarGrid = ({
   );
 
   // Get the number of weeks in the month so we can render the proper number of rows.
-  const weeksInMonth = getWeeksInMonth(state.visibleRange.start, locale);
+  const weeksInMonth = getWeeksInMonth(startDate, locale);
 
   return (
     <GridContainer


### PR DESCRIPTION
Use updated date while calculating weeks in a month