### PR TITLE
Given zIndex 2 to button.

### DIFF
--- a/packages/docs/static/doc-snippets/examples-music-player.mdx
+++ b/packages/docs/static/doc-snippets/examples-music-player.mdx
@@ -32,7 +32,7 @@ imports: import { Box, Button, Heading, Text } from '@sparrowengg/twigs-react'
         padding: 10,
         borderRadius: '100%',
         width: '$10',
-
+        zIndex:'2',
         svg: {
           display: 'block',
           marginRight: '-$2'


### PR DESCRIPTION
<img width="892" alt="image" src="https://github.com/user-attachments/assets/0b4329d4-1998-4043-8aa8-fdbe0ad0e48a" />

The Music Player button had a bug where the cursor did not show as a pointer on hover, and the music did not play. This has been fixed in this PR.