### PR TITLE
Omit content from inferred type to fix typescript issues

### DIFF
--- a/packages/docs/docs/components/tooltip.mdx
+++ b/packages/docs/docs/components/tooltip.mdx
@@ -17,12 +17,12 @@ You should wrap your application with `TooltipProvider` to make sure that the to
 ```jsx
 function App() {
   return (
-      // highlight-start
+    // highlight-start
     <TooltipProvider delayDuration={0}>
       // highlight-end
       <App />
     </TooltipProvider>
-  )
+  );
 }
 ```
 
@@ -33,7 +33,7 @@ function App() {
 ```jsx
 // highlight-start
 <Tooltip content="Tooltip content">
-// highlight-end
+  // highlight-end
   <Button> Hover me </Button>
 </Tooltip>
 ```
@@ -41,14 +41,18 @@ function App() {
 ### Props
 
 #### TooltipProvider
+
 | Property          | Description                                                                       | Type   | Default |
-|-------------------|-----------------------------------------------------------------------------------|--------|---------|
+| ----------------- | --------------------------------------------------------------------------------- | ------ | ------- |
 | delayDuration     | The duration from when the mouse enters a tooltip trigger until the tooltip opens | number | 700     |
 | skipDelayDuration | time a user has to enter another trigger without incurring a delay again          | number | 300     |
 
 #### Tooltip
-| Property | Description                                 | Type                  | Default |
-|----------|---------------------------------------------|-----------------------|---------|
-| side     | position of tooltip                         | `bottom` `left` `right` `top` | top     |
-| content  | Content inside tooltip                      | string,JSX            |         |
-| align    | The preferred alignment against the trigger | `start` `center` `end`      | start   |
+
+| Property                | Description                                                                       | Type                          | Default |
+| ----------------------- | --------------------------------------------------------------------------------- | ----------------------------- | ------- |
+| side                    | position of tooltip                                                               | `bottom` `left` `right` `top` | top     |
+| content                 | Content inside tooltip                                                            | string,JSX                    |         |
+| align                   | The preferred alignment against the trigger                                       | `start` `center` `end`        | start   |
+| delayDuration           | The duration from when the mouse enters a tooltip trigger until the tooltip opens | number                        | 700     |
+| disableHoverableContent | Prevents TooltipContent from remaining open when hovering                         | `boolean`                     | false   |

--- a/packages/react-components/src/tooltip/tooltip.tsx
+++ b/packages/react-components/src/tooltip/tooltip.tsx
@@ -85,7 +85,7 @@ interface TooltipBaseProps {
 }
 
 export type TooltipProps = TooltipBaseProps &
-  ComponentProps<typeof StyledContent> &
+  Omit<ComponentProps<typeof StyledContent>, 'content'> &
   ComponentProps<typeof TooltipPrimitive.Root>;
 
 export const Tooltip = ({

--- a/packages/react-components/src/tooltip/tooltip.tsx
+++ b/packages/react-components/src/tooltip/tooltip.tsx
@@ -96,6 +96,8 @@ export const Tooltip = ({
   size,
   open,
   defaultOpen,
+  delayDuration,
+  disableHoverableContent,
   onOpenChange,
   ...props
 }: TooltipProps) => {
@@ -104,6 +106,8 @@ export const Tooltip = ({
       open={open}
       defaultOpen={defaultOpen}
       onOpenChange={onOpenChange}
+      delayDuration={delayDuration}
+      disableHoverableContent={disableHoverableContent}
     >
       <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
       {content ? (


### PR DESCRIPTION
- Omit content from inferred type to fix typescript issues
- Add `delayDuration` and `disableHoverableContent` prop to Tooltip root