### PR TITLE
Manual workflows

### DIFF
--- a/.github/workflows/npm-publish-react-editor-manually.yml
+++ b/.github/workflows/npm-publish-react-editor-manually.yml
@@ -1,0 +1,32 @@
+# This workflow will run tests using node and then publish a package
+name: Publish react editor manually
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-test-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build and Test
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: yarn
+      - name: Playwright install
+        run: npx playwright install --with-deps chromium
+      - run: yarn build:editor
+      - run: yarn test
+      - name: Publish to npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: cd packages/react-editor && npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token_react_components}}

--- a/.github/workflows/npm-publish-react-icons-manually.yml
+++ b/.github/workflows/npm-publish-react-icons-manually.yml
@@ -19,8 +19,6 @@ jobs:
           node-version: 20
       - run: yarn
       - run: yarn build:icons
-      - run: npx playwright install --with-deps chromium
-      - run: yarn test
       - name: Publish to npm
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/npm-publish-react-icons-manually.yml
+++ b/.github/workflows/npm-publish-react-icons-manually.yml
@@ -1,0 +1,31 @@
+# This workflow will run tests using node and then publish a package
+name: Publish react icons manually
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-test-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build and Test
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: yarn
+      - run: yarn build:icons
+      - run: npx playwright install --with-deps chromium
+      - run: yarn test
+      - name: Publish to npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: cd packages/react-icons && npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token_react_icons}}

--- a/.github/workflows/npm-publish-react-icons.yml
+++ b/.github/workflows/npm-publish-react-icons.yml
@@ -22,6 +22,7 @@ jobs:
           node-version: 20
       - run: yarn
       - run: yarn build:icons
+      - run: npx playwright install --with-deps chromium
       - run: yarn test
       - name: Publish to npm
         uses: actions/setup-node@v3

--- a/.github/workflows/npm-publish-react-icons.yml
+++ b/.github/workflows/npm-publish-react-icons.yml
@@ -22,8 +22,6 @@ jobs:
           node-version: 20
       - run: yarn
       - run: yarn build:icons
-      - run: npx playwright install --with-deps chromium
-      - run: yarn test
       - name: Publish to npm
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
- Add manually triggered workflows for publishing icons and editor
- Remove test step from icon workflows since icons don't have test cases