### PR TITLE
Fix wrong window instance in editor dialog

### DIFF
--- a/packages/react-editor/src/components/dialog-link-editor/index.tsx
+++ b/packages/react-editor/src/components/dialog-link-editor/index.tsx
@@ -122,7 +122,7 @@ function useDialogLinkEditorToolbar(
       }
     }
 
-    const nativeSelection = getDOMSelection(editor._window);
+    const nativeSelection = getDOMSelection(editor._window ?? window);
     const { activeElement } = document;
 
     const rootElement = editor.getRootElement();

--- a/packages/react-editor/src/components/dialog-link-editor/index.tsx
+++ b/packages/react-editor/src/components/dialog-link-editor/index.tsx
@@ -19,7 +19,8 @@ import {
   LexicalEditor,
   NodeSelection,
   RangeSelection,
-  SELECTION_CHANGE_COMMAND
+  SELECTION_CHANGE_COMMAND,
+  getDOMSelection
 } from 'lexical';
 import {
   useCallback, useEffect, useRef, useState
@@ -121,7 +122,7 @@ function useDialogLinkEditorToolbar(
       }
     }
 
-    const nativeSelection = window.getSelection();
+    const nativeSelection = getDOMSelection(editor._window);
     const { activeElement } = document;
 
     const rootElement = editor.getRootElement();


### PR DESCRIPTION
Use `getDOMSelection` util function instead of `window.getSelection()`, and replace `window` with `editor._window`. Fixes issues when the editor is inside an iframe and the dialog is opened outside of the iframe