### PR TITLE
updated the flow towards enterprise version

### DIFF
--- a/packages/fuma-docs/src/component/upgrade-guide/upgrade-guide.tsx
+++ b/packages/fuma-docs/src/component/upgrade-guide/upgrade-guide.tsx
@@ -185,7 +185,7 @@ export const UpgradeGuide = () => {
   return (
     <Box>
       <Script
-        src={`https://www.google.com/recaptcha/api.js?render=${PUBLIC_RECAPTCHA_SITE_KEY}`}
+        src={`https://www.google.com/recaptcha/enterprise.js?render=${PUBLIC_RECAPTCHA_SITE_KEY}`}
         strategy="afterInteractive"
       />
       <form

--- a/packages/fuma-docs/src/lib/utils.ts
+++ b/packages/fuma-docs/src/lib/utils.ts
@@ -7,7 +7,7 @@ export const getRecaptchaToken = async (
 ): Promise<string> => {
   const getToken = async (retryCount = 0): Promise<string> => {
     return new Promise((resolve, reject) => {
-      if (!window.grecaptcha) {
+      if (!window.grecaptcha?.enterprise) {
         if (retryCount >= MAX_RETRIES) {
           reject(new Error("Failed to load reCAPTCHA after maximum retries"));
           return;

--- a/packages/fuma-docs/src/lib/utils.ts
+++ b/packages/fuma-docs/src/lib/utils.ts
@@ -17,9 +17,9 @@ export const getRecaptchaToken = async (
         }, 1000);
         return;
       }
-      grecaptcha.ready(function () {
+      grecaptcha.enterprise.ready(function () {
         grecaptcha
-          .execute(recaptchaSiteKey, {
+          .enterprise.execute(recaptchaSiteKey, {
             action: "submit",
           })
           .then(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes client-side reCAPTCHA initialization and token generation; misconfiguration or API differences could prevent token creation and block upgrade-guide requests.
> 
> **Overview**
> Migrates the upgrade-guide form’s bot protection from standard reCAPTCHA to **reCAPTCHA Enterprise** by swapping the loaded script (`recaptcha/api.js` -> `recaptcha/enterprise.js`).
> 
> Updates `getRecaptchaToken` to wait for `window.grecaptcha.enterprise` and to call `grecaptcha.enterprise.ready()`/`grecaptcha.enterprise.execute()` when generating the submit token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bf6570bb42d107efc85aaddf8b59a91daeee7a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->