### PR TITLE
updated conditions for link handling

### DIFF
--- a/packages/react-editor/src/components/dialog-link-editor/index.tsx
+++ b/packages/react-editor/src/components/dialog-link-editor/index.tsx
@@ -62,7 +62,7 @@ function useDialogLinkEditorToolbar(
         const autoLinkParent = $findMatchingParent(node, $isAutoLinkNode);
         if (linkParent !== null && autoLinkParent === null) {
           setIsLink(true);
-        } else {
+        } else if (!isNewLink.current) {
           setIsLink(false);
         }
       }
@@ -152,8 +152,10 @@ function useDialogLinkEditorToolbar(
           setFloatingElemPositionForLinkEditor(null, containerElem, anchorElem);
         }
       }, 10);
-      setLastSelection(null);
-      setLinkUrl('');
+      if (!isNewLink.current) {
+        setLastSelection(null);
+        setLinkUrl('');
+      }
     }
 
     // eslint-disable-next-line consistent-return


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI state tweak confined to the link editor; main risk is subtle regressions in when the link tooltip/dialog hides or clears input during selection changes.
> 
> **Overview**
> Prevents the link toolbar from being cleared while a *new* link is being created.
> 
> `dialog-link-editor` now gates `setIsLink(false)` and the reset of `lastSelection`/`linkUrl` behind `!isNewLink.current`, avoiding premature state resets during selection/DOM focus changes when opening the link dialog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657f8f527856186423c691c2b907e637d1c60104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->